### PR TITLE
Altered the process, checks moved to client-side

### DIFF
--- a/assets/js/chat.js
+++ b/assets/js/chat.js
@@ -36,7 +36,6 @@ function renderOnlineUsers(presence) {
 function checkAndConnect(value, callback) {
 	const username = value ?? sessionStorage.getItem("username");
 	if (!username) {
-		// Handle the case where username is not provided
 		usernameForm()
 			.then((resolvedUsername) => {
 				sessionStorage.setItem("username", resolvedUsername);
@@ -63,17 +62,17 @@ function connectToChannel(username, callback) {
 	});
 	window.channel = channel;
 	const presence = new Presence(channel);
-	presence.onSync(() => renderOnlineUsers(presence, channel));
 	channel
 		.join()
 		.receive("ok", () => {
 			showToast("Connected to channel.", "success");
 			if (callback) {
+                presence.onSync(() => renderOnlineUsers(presence, channel));
 				callback(channel, username);
 			}
 		})
 		.receive("error", () => {
-			showToast("Unable to join channel.", "danger");
+            window.location.href = "/"
 		});
 
 	return { channel, username };

--- a/lib/chatsec_web/controllers/page_controller.ex
+++ b/lib/chatsec_web/controllers/page_controller.ex
@@ -3,8 +3,6 @@ defmodule ChatsecWeb.PageController do
   use ChatsecWeb, :controller
 
   def home(conn, _params) do
-    # The home page is often custom made,
-    # so skip the default app layout.
     render(conn, :home, layout: false)
   end
 
@@ -14,19 +12,15 @@ defmodule ChatsecWeb.PageController do
     redirect(conn, to: ~p"/chat/#{uuid}")
   end
 
+  def room_not_found(conn, _params) do
+    render(conn, :room_not_found, layout: false)
+  end
+
   def chat(conn, %{"chat_id" => chatid}) do
-    if chatid in ChannelState.get_rooms() and check_if_private(chatid) do
+    if chatid in ChannelState.get_rooms() do
       render(conn, :chat, layout: false)
     else
       render(conn, :room_not_found, layout: false)
-    end
-  end
-
-  defp check_if_private(chatid) do
-    users_in_chat = ChannelState.list_users(chatid)
-
-    if Enum.count(users_in_chat) < 2 do
-      true
     end
   end
 end


### PR DESCRIPTION
Certain checks to see if a chatroom was 'full' were not implemented correctly which caused some unwanted behaviour. Moved these checks to the client-side, which works better and does not causes bugs.