### PR TITLE
iOS home-screen icon and README polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+<p align="center">
+  <a href="https://chatsec.app">
+    <img src="priv/static/images/logo.svg" alt="ChatSec logo" width="96" />
+  </a>
+</p>
+
 # [ChatSec 🔒](https://chatsec.app)
 
 **ChatSec** is an end-to-end encrypted, ephemeral chat application built with [Elixir](https://elixir-lang.org/) and the [Phoenix Framework](https://www.phoenixframework.org/). No accounts, no logs, no history — just a secure, private conversation.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
   </a>
 </p>
 
-# [ChatSec 🔒](https://chatsec.app)
+# [ChatSec](https://chatsec.app)
 
 **ChatSec** is an end-to-end encrypted, ephemeral chat application built with [Elixir](https://elixir-lang.org/) and the [Phoenix Framework](https://www.phoenixframework.org/). No accounts, no logs, no history — just a secure, private conversation.
 


### PR DESCRIPTION
## Summary
- Added apple-touch-icon.png (180x180, rasterized from logo.svg with a solid dark background) and wired it up in root.html.heex, so the logo shows correctly when the site is added to an iOS home screen
- Added the logo to the top of the README, centered and linked to the live site
- Dropped the now-redundant lock emoji from the README title (the logo carries that visual now)

🤖 Generated with [Claude Code](https://claude.com/claude-code)