### PR TITLE
Redesign error pages to match the rest of the app

### DIFF
--- a/e2e/tests/test_error_pages.py
+++ b/e2e/tests/test_error_pages.py
@@ -8,7 +8,7 @@ from conftest import ROOM_PATH_RE
 def test_unknown_room_shows_room_not_found(page, base_url):
     page.goto(f"{base_url}/chat/does-not-exist")
 
-    expect(page.get_by_text("Room Not Found")).to_be_visible()
+    expect(page.get_by_text("Room not found")).to_be_visible()
     expect(page.get_by_role("link", name="Go home")).to_be_visible()
     expect(page.locator("#create-room-button")).to_be_visible()
 
@@ -25,5 +25,5 @@ def test_unknown_path_shows_404(page, base_url):
     page.goto(f"{base_url}/not-a-real-path")
 
     expect(page.get_by_text("404")).to_be_visible()
-    expect(page.get_by_text("Page Not Found")).to_be_visible()
+    expect(page.get_by_text("Page not found")).to_be_visible()
     expect(page.get_by_role("link", name="Go home")).to_be_visible()

--- a/lib/chatsec_web/controllers/error_html/404.html.heex
+++ b/lib/chatsec_web/controllers/error_html/404.html.heex
@@ -1,12 +1,34 @@
-<section class="flex items-center justify-center mt-8">
-  <div class="text-center">
-    <h1 class="text-9xl font-extrabold text-white">404</h1>
-    <p class="text-2xl font-semibold text-gray-700 mt-4">Page Not Found</p>
-    <p class="text-gray-500 mt-2 mb-6">Sorry, the page you're looking for doesn't exist.</p>
-    <a href="/">
-      <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 shadow-md">
-        Go home
-      </button>
+<div class="relative flex h-dvh items-center justify-center overflow-hidden bg-gray-900 px-6 text-center text-white">
+  <div class="pointer-events-none fixed inset-0 overflow-hidden">
+    <div class="absolute -top-24 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-600/20 blur-3xl">
+    </div>
+  </div>
+
+  <div class="relative flex flex-col items-center">
+    <div class="drop-shadow-[0_0_40px_rgba(139,92,246,0.35)]">
+      <svg viewBox="0 0 200 200" class="h-16 w-16" aria-hidden="true">
+        <defs>
+          <linearGradient id="logoGrad404" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#a78bfa" />
+            <stop offset="100%" stop-color="#4c1d95" />
+          </linearGradient>
+        </defs>
+        <path d="M58 134C56 152 48 168 34 180C57 173 74 158 82 136Z" fill="url(#logoGrad404)" />
+        <rect x="20" y="24" width="160" height="116" rx="36" fill="url(#logoGrad404)" />
+        <circle cx="100" cy="72" r="17" fill="#f5f3ff" />
+        <path d="M91 84L109 84L116 114Q100 124 84 114Z" fill="#f5f3ff" />
+      </svg>
+    </div>
+
+    <h1 class="mt-6 text-8xl font-extrabold tracking-tight text-white sm:text-9xl">404</h1>
+    <p class="mt-4 text-xl font-semibold text-white">Page not found</p>
+    <p class="mt-2 max-w-sm text-gray-400">Sorry, the page you're looking for doesn't exist.</p>
+
+    <a
+      href="/"
+      class="mt-8 rounded-lg bg-violet-500 px-6 py-3 font-bold text-white shadow-md transition duration-200 ease-in-out hover:scale-105 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-opacity-50"
+    >
+      Go home
     </a>
   </div>
-</section>
+</div>

--- a/lib/chatsec_web/controllers/error_html/500.html.heex
+++ b/lib/chatsec_web/controllers/error_html/500.html.heex
@@ -1,11 +1,34 @@
-<section class="flex items-center justify-center mt-8">
-  <div class="text-center">
-    <h1 class="text-9xl font-extrabold text-white">500</h1>
-    <p class="text-2xl font-semibold text-gray-700 mt-4 mb-6">Something went wrong?</p>
-    <a href="/">
-      <button class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-opacity-50 shadow-md">
-        Go home
-      </button>
+<div class="relative flex h-dvh items-center justify-center overflow-hidden bg-gray-900 px-6 text-center text-white">
+  <div class="pointer-events-none fixed inset-0 overflow-hidden">
+    <div class="absolute -top-24 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-600/20 blur-3xl">
+    </div>
+  </div>
+
+  <div class="relative flex flex-col items-center">
+    <div class="drop-shadow-[0_0_40px_rgba(139,92,246,0.35)]">
+      <svg viewBox="0 0 200 200" class="h-16 w-16" aria-hidden="true">
+        <defs>
+          <linearGradient id="logoGrad500" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#a78bfa" />
+            <stop offset="100%" stop-color="#4c1d95" />
+          </linearGradient>
+        </defs>
+        <path d="M58 134C56 152 48 168 34 180C57 173 74 158 82 136Z" fill="url(#logoGrad500)" />
+        <rect x="20" y="24" width="160" height="116" rx="36" fill="url(#logoGrad500)" />
+        <circle cx="100" cy="72" r="17" fill="#f5f3ff" />
+        <path d="M91 84L109 84L116 114Q100 124 84 114Z" fill="#f5f3ff" />
+      </svg>
+    </div>
+
+    <h1 class="mt-6 text-8xl font-extrabold tracking-tight text-white sm:text-9xl">500</h1>
+    <p class="mt-4 text-xl font-semibold text-white">Something went wrong</p>
+    <p class="mt-2 max-w-sm text-gray-400">An unexpected error occurred. Try again in a moment.</p>
+
+    <a
+      href="/"
+      class="mt-8 rounded-lg bg-violet-500 px-6 py-3 font-bold text-white shadow-md transition duration-200 ease-in-out hover:scale-105 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-opacity-50"
+    >
+      Go home
     </a>
   </div>
-</section>
+</div>

--- a/lib/chatsec_web/controllers/page_html/room_not_found.heex
+++ b/lib/chatsec_web/controllers/page_html/room_not_found.heex
@@ -1,25 +1,45 @@
-<section class="flex items-center justify-center mt-8">
-  <div class="text-center">
-    <h1 class="text-9xl font-extrabold text-white">Sorry.</h1>
-    <p class="text-2xl font-semibold text-gray-700 mt-4">Room Not Found</p>
-    <p class="text-gray-500 mt-2 mb-6">
-      The room you're looking for is private or doesn't exist.
-    </p>
+<div class="relative flex h-dvh items-center justify-center overflow-hidden bg-gray-900 px-6 text-center text-white">
+  <div class="pointer-events-none fixed inset-0 overflow-hidden">
+    <div class="absolute -top-24 left-1/2 h-96 w-96 -translate-x-1/2 rounded-full bg-violet-600/20 blur-3xl">
+    </div>
+  </div>
 
-    <div class="mt-3 flex justify-center items-center space-x-3">
+  <div class="relative flex flex-col items-center">
+    <div class="drop-shadow-[0_0_40px_rgba(139,92,246,0.35)]">
+      <svg viewBox="0 0 200 200" class="h-16 w-16" aria-hidden="true">
+        <defs>
+          <linearGradient id="logoGradRoomNotFound" x1="0%" y1="0%" x2="100%" y2="100%">
+            <stop offset="0%" stop-color="#a78bfa" />
+            <stop offset="100%" stop-color="#4c1d95" />
+          </linearGradient>
+        </defs>
+        <path
+          d="M58 134C56 152 48 168 34 180C57 173 74 158 82 136Z"
+          fill="url(#logoGradRoomNotFound)"
+        />
+        <rect x="20" y="24" width="160" height="116" rx="36" fill="url(#logoGradRoomNotFound)" />
+        <circle cx="100" cy="72" r="17" fill="#f5f3ff" />
+        <path d="M91 84L109 84L116 114Q100 124 84 114Z" fill="#f5f3ff" />
+      </svg>
+    </div>
+
+    <h1 class="mt-6 text-7xl font-extrabold tracking-tight text-white sm:text-8xl">Sorry.</h1>
+    <p class="mt-4 text-xl font-semibold text-white">Room not found</p>
+    <p class="mt-2 max-w-sm text-gray-400">This room is private or doesn't exist.</p>
+
+    <div class="mt-8 flex items-center gap-3">
       <a
         href="/"
-        class="bg-emerald-500 hover:bg-emerald-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:ring-opacity-50 shadow-md"
+        class="rounded-lg bg-gray-700 px-6 py-3 font-bold text-white shadow-md transition duration-200 ease-in-out hover:scale-105 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-opacity-50"
       >
         Go home
       </a>
-      <p class="text-white">or</p>
       <button
         id="create-room-button"
-        class="bg-purple-500 hover:bg-purple-700 text-white font-bold py-2 px-4 rounded transition duration-200 ease-in-out transform hover:scale-105 focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-opacity-50 shadow-md"
+        class="rounded-lg bg-violet-500 px-6 py-3 font-bold text-white shadow-md transition duration-200 ease-in-out hover:scale-105 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 focus:ring-opacity-50"
       >
         Create room
       </button>
     </div>
   </div>
-</section>
+</div>


### PR DESCRIPTION
## Summary
- 404, 500, and room-not-found pages now use the same dark theme, logo mark, and violet accent styling as the landing page/chatroom/modals, instead of the old mismatched blue/emerald/purple buttons on a plain layout
- Copy switched to sentence case for consistency with the rest of the redesigned text

## Test plan
- [x] `mix test` - 20 passing
- [x] e2e suite - 31 passing, run against a live dev server