### PR TITLE
Add typing indicator and unfocused-tab message notification

### DIFF
--- a/assets/js/message.js
+++ b/assets/js/message.js
@@ -4,6 +4,11 @@ import { showToast } from "./toast";
 const USERNAME_KEY = "username";
 const SELF_COLOR = "rgb(138, 255, 156)";
 const OTHER_COLOR = "rgb(255, 128, 197)";
+// How often we'll push a "typing" event while the peer is actively typing,
+// and how long their indicator stays up after the last one we received.
+const TYPING_THROTTLE_MS = 2_000;
+const TYPING_HIDE_MS = 3_000;
+const DEFAULT_TITLE = document.title;
 // --- module state ---
 let secretKey;
 let currentChannel;
@@ -11,6 +16,9 @@ let currentUsername;
 let currentMessagesContainer;
 let currentFingerprint;
 let initialized = false;
+let lastTypingSentAt = 0;
+let typingHideTimeout;
+let unseenCount = 0;
 // --- dom helpers ---
 function buildMessageEl(messageUsername, isSelf) {
 	const usernameEl = document.createElement("span");
@@ -35,6 +43,19 @@ function renderMessage(messageUsername, text, isSelf) {
 	messageEl.innerText = text;
 	currentMessagesContainer.appendChild(container);
 	container.scrollIntoView({ behavior: "smooth", block: "end" });
+}
+function setTypingIndicatorVisible(visible) {
+	document.getElementById("typing-indicator")?.classList.toggle("hidden", !visible);
+}
+function markUnseenMessage() {
+	if (document.hasFocus()) return;
+	unseenCount += 1;
+	document.title = `(${unseenCount}) ${DEFAULT_TITLE}`;
+}
+function clearUnseenMessages() {
+	if (unseenCount === 0) return;
+	unseenCount = 0;
+	document.title = DEFAULT_TITLE;
 }
 // --- event handlers ---
 async function sendMessage(chatInput) {
@@ -65,7 +86,21 @@ async function handleKeyDown(event) {
 	event.preventDefault();
 	await sendMessage(event.currentTarget);
 }
+function handleTypingInput() {
+	if (!secretKey || !currentChannel) return;
+	const now = Date.now();
+	if (now - lastTypingSentAt < TYPING_THROTTLE_MS) return;
+	lastTypingSentAt = now;
+	currentChannel.push("typing", {});
+}
+function handleTypingReceived() {
+	setTypingIndicatorVisible(true);
+	clearTimeout(typingHideTimeout);
+	typingHideTimeout = setTimeout(() => setTypingIndicatorVisible(false), TYPING_HIDE_MS);
+}
 async function handleNewMsg(payload) {
+	clearTimeout(typingHideTimeout);
+	setTypingIndicatorVisible(false);
 	if (!payload.body) {
 		console.warn("Received message with no body", payload);
 		return;
@@ -73,6 +108,7 @@ async function handleNewMsg(payload) {
 	try {
 		const decrypted = await decryptMessage(secretKey, payload.body, payload.iv, payload.username);
 		renderMessage(payload.username, decrypted, false);
+		markUnseenMessage();
 	} catch (_) {
 		showToast("Failed to decrypt message.", "danger");
 	}
@@ -97,8 +133,11 @@ async function sendAndReceiveMessages(chatInput, username, channel, messagesCont
 	currentMessagesContainer = messagesContainer;
 	if (!initialized) {
 		chatInput.addEventListener("keydown", handleKeyDown);
+		chatInput.addEventListener("input", handleTypingInput);
 		channel.on("new_msg", handleNewMsg);
+		channel.on("typing", handleTypingReceived);
 		channel.on("room_deleted", handleRoomDeleted);
+		window.addEventListener("focus", clearUnseenMessages);
 		initialized = true;
 	}
 	return currentFingerprint;

--- a/e2e/tests/test_chat_room.py
+++ b/e2e/tests/test_chat_room.py
@@ -1,3 +1,5 @@
+import re
+
 from playwright.sync_api import expect
 
 from conftest import create_room, join_room, send_message, wait_for_send_ready
@@ -94,6 +96,61 @@ def test_enter_sends_shift_enter_inserts_newline(make_page, base_url):
     expect(chat_input).to_have_value("")
     expect(bob.locator("#messages")).to_contain_text("line one")
     expect(bob.locator("#messages")).to_contain_text("line two")
+
+
+def test_typing_indicator_shows_then_clears_after_inactivity(make_page, base_url):
+    alice = make_page()
+    room_url = create_room(alice, base_url, "Alice")
+    bob = make_page()
+    join_room(bob, room_url, "Bob")
+    wait_for_send_ready(alice)
+    wait_for_send_ready(bob)
+
+    expect(bob.locator("#typing-indicator")).to_be_hidden()
+    alice.locator("#chat-input").press_sequentially("h")
+    expect(bob.locator("#typing-indicator")).to_be_visible(timeout=2000)
+
+    # No explicit "stop typing" event - the indicator times itself out after
+    # a few seconds of no further "typing" pushes (TYPING_HIDE_MS in message.js).
+    expect(bob.locator("#typing-indicator")).to_be_hidden(timeout=5000)
+
+
+def test_typing_indicator_hides_immediately_once_message_arrives(make_page, base_url):
+    alice = make_page()
+    room_url = create_room(alice, base_url, "Alice")
+    bob = make_page()
+    join_room(bob, room_url, "Bob")
+    wait_for_send_ready(alice)
+    wait_for_send_ready(bob)
+
+    chat_input = alice.locator("#chat-input")
+    chat_input.press_sequentially("Hi Bob")
+    expect(bob.locator("#typing-indicator")).to_be_visible(timeout=2000)
+
+    chat_input.press("Enter")
+    expect(bob.locator("#messages")).to_contain_text("Hi Bob")
+    expect(bob.locator("#typing-indicator")).to_be_hidden()
+
+
+def test_document_title_flags_unseen_message_when_tab_unfocused(make_page, base_url):
+    alice = make_page()
+    room_url = create_room(alice, base_url, "Alice")
+    bob = make_page()
+    join_room(bob, room_url, "Bob")
+    wait_for_send_ready(alice)
+    wait_for_send_ready(bob)
+
+    default_title = bob.title()
+
+    # Headless multi-context focus isn't something real OS window-manager
+    # focus drives predictably, so force the check the app actually makes.
+    bob.evaluate("() => { document.hasFocus = () => false; }")
+
+    send_message(alice, "Hey Bob")
+    expect(bob).to_have_title(re.compile(r"^\(1\) "), timeout=5000)
+
+    bob.evaluate("() => window.dispatchEvent(new Event('focus'))")
+    expect(bob).to_have_title(default_title)
 
 
 def test_invite_modal_shows_room_url_and_copy_shows_toast(make_page, base_url):

--- a/lib/chatsec_web/channels/room_channel.ex
+++ b/lib/chatsec_web/channels/room_channel.ex
@@ -8,9 +8,9 @@ defmodule ChatsecWeb.RoomChannel do
   # never trust the client for the actual guarantee.
   @username_regex ~r/^[a-zA-Z0-9 ]{1,32}$/
   @max_message_bytes 8_000
-  # Bounds how fast a single connection can push publickey/new_msg events -
-  # generous for real typing, but stops one peer from flooding the other's
-  # browser or forcing repeated expensive ECDH derivations.
+  # Bounds how fast a single connection can push publickey/new_msg/typing
+  # events - generous for real typing, but stops one peer from flooding the
+  # other's browser or forcing repeated expensive ECDH derivations.
   @rate_limit_window_ms 5_000
   @rate_limit_max_events 20
 
@@ -58,6 +58,20 @@ defmodule ChatsecWeb.RoomChannel do
           "iv" => iv
         })
 
+        {:noreply, socket}
+
+      {:error, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  # No payload needed - a room only ever has the two peers, so "typing" is
+  # unambiguous about who. Client-side throttles how often this is sent;
+  # this shares the same rate limit as everything else as a backstop.
+  def handle_in("typing", _params, socket) do
+    case check_rate_limit(socket) do
+      {:ok, socket} ->
+        broadcast_from!(socket, "typing", %{})
         {:noreply, socket}
 
       {:error, socket} ->

--- a/lib/chatsec_web/controllers/page_html/chat.html.heex
+++ b/lib/chatsec_web/controllers/page_html/chat.html.heex
@@ -63,6 +63,7 @@
 
   <%!-- Input bar --%>
   <footer class="relative z-10 shrink-0 border-t border-gray-700 bg-gray-900 px-3 py-2">
+    <p id="typing-indicator" class="hidden mb-1 px-1 text-xs italic text-gray-400">Typing...</p>
     <div class="flex items-end gap-2 rounded-2xl border border-gray-700 bg-gray-800 px-3 py-2">
       <textarea
         id="chat-input"

--- a/test/chatsec_web/channels/room_channel_test.exs
+++ b/test/chatsec_web/channels/room_channel_test.exs
@@ -60,6 +60,18 @@ defmodule ChatsecWeb.RoomChannelTest do
     refute_push "new_msg", %{}, 100
   end
 
+  test "typing is delivered to the other peer but not echoed back to the sender", %{
+    room_id: room_id
+  } do
+    {:ok, _, alice} = join_room(socket_fixture(), room_id, "Alice")
+    {:ok, _, _bob} = join_room(socket_fixture(), room_id, "Bob")
+
+    push(alice, "typing", %{})
+
+    assert_push "typing", %{}, 500
+    refute_push "typing", %{}, 100
+  end
+
   test "an oversized new_msg is dropped instead of broadcast", %{room_id: room_id} do
     {:ok, _, socket} = join_room(socket_fixture(), room_id, "Alice")
 


### PR DESCRIPTION
## Summary
- `RoomChannel` relays a lightweight `typing` event (rate-limited and `broadcast_from!` like `new_msg`/`publickey`). The client throttles pushing it to once per 2s while the input has focus.
- The peer sees a "Typing..." line above the input bar that clears itself after 3s of inactivity, or immediately once a real message arrives - no explicit "stop typing" signal needed.
- `document.title` picks up an `(N)` unseen-message prefix when a message decrypts while the tab is unfocused (`document.hasFocus()` false), clearing back to the page's own title on window focus.

## Test plan
- [x] `mix test` - 21/21 passing (new test: typing is broadcast_from!, not echoed to sender)
- [x] Full e2e suite - 34/34 passing (new: typing indicator shows/auto-clears, hides immediately on message arrival, title flags unseen message and clears on focus)
- [x] Manually verified both features live in the browser with two independent peers

🤖 Generated with [Claude Code](https://claude.com/claude-code)