### PR TITLE
Add a self-destruct timer for chat rooms

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -9,6 +9,7 @@ import { handshake } from "./handshake.js";
 import { sendAndReceiveMessages, sendMessage } from "./message.js";
 import { donateModal } from "./donate.js";
 import { setFingerprint, showFingerprintModal } from "./fingerprint.js";
+import { initTimer } from "./timer.js";
 function initLiveSocket() {
     const csrfToken = document
         .querySelector("meta[name='csrf-token']")
@@ -81,6 +82,7 @@ function initChatPage() {
         });
     document.getElementById("verify-button")?.addEventListener("click", showFingerprintModal);
     checkAndConnect(null, (channel, username) => {
+        initTimer(channel);
         sendAndReceiveMessages(chatInput, username, channel, messagesContainer).then((fingerprint) => {
             sendBtn.disabled = false;
             sendBtn.classList.remove("opacity-50", "cursor-not-allowed");

--- a/assets/js/timer.js
+++ b/assets/js/timer.js
@@ -1,0 +1,90 @@
+import { showToast } from "./toast";
+import { openModal, modalShell, BTN_SECONDARY } from "./modal";
+const TIMER_ICON = `
+  <svg class="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+    <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+  </svg>
+`;
+const OPTIONS = [
+	{ minutes: 0, label: "Off" },
+	{ minutes: 10, label: "10 min" },
+	{ minutes: 30, label: "30 min" },
+	{ minutes: 60, label: "60 min" },
+];
+const OPTION_BUTTON_CLASS =
+	"rounded-lg border border-gray-700 bg-gray-900 px-3 py-2 text-sm font-semibold text-white " +
+	"transition hover:border-violet-500 hover:bg-gray-800 focus:outline-none focus:ring-2 focus:ring-violet-500";
+// --- module state ---
+let currentChannel;
+let countdownInterval;
+let expiresAt = null;
+function formatRemaining(ms) {
+	const totalSeconds = Math.max(0, Math.round(ms / 1000));
+	const minutes = Math.floor(totalSeconds / 60);
+	const seconds = totalSeconds % 60;
+	return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+function updateButtonLabel() {
+	const button = document.getElementById("timer-button");
+	if (!button) return;
+	if (!expiresAt) {
+		button.textContent = "Timer";
+		return;
+	}
+	const remaining = expiresAt - Date.now();
+	if (remaining <= 0) {
+		clearInterval(countdownInterval);
+	}
+	button.textContent = formatRemaining(remaining);
+}
+function startCountdown(ms) {
+	clearInterval(countdownInterval);
+	if (!ms) {
+		expiresAt = null;
+		updateButtonLabel();
+		return;
+	}
+	expiresAt = Date.now() + ms;
+	updateButtonLabel();
+	countdownInterval = setInterval(updateButtonLabel, 1000);
+}
+function handleTimerSet(payload) {
+	startCountdown(payload.ms);
+}
+function showTimerModal() {
+	const options = OPTIONS.map(
+		({ minutes, label }) =>
+			`<button data-minutes="${minutes}" class="${OPTION_BUTTON_CLASS}">${label}</button>`,
+	).join("");
+	const body = `
+    <p class="mb-4 text-sm text-gray-400">
+      Automatically delete this room after a set time, no matter what.
+    </p>
+    <div class="mb-4 grid grid-cols-2 gap-2">${options}</div>
+    <div class="flex justify-end">
+      <button id="closeModalButton" class="${BTN_SECONDARY}">Cancel</button>
+    </div>
+  `;
+	const { close, container } = openModal(
+		"timerModal",
+		modalShell(TIMER_ICON, "Self-destruct timer", body),
+	);
+	document.getElementById("closeModalButton").addEventListener("click", close);
+	container.querySelectorAll("[data-minutes]").forEach((button) => {
+		button.addEventListener("click", () => {
+			const minutes = Number(button.dataset.minutes);
+			try {
+				currentChannel.push("set_timer", { minutes });
+			} catch (_) {
+				showToast("Failed to set timer!", "danger");
+			}
+			close();
+		});
+	});
+}
+function initTimer(channel) {
+	currentChannel = channel;
+	channel.on("timer_set", handleTimerSet);
+	document.getElementById("timer-button")?.addEventListener("click", showTimerModal);
+}
+export { initTimer };

--- a/e2e/tests/test_chat_room.py
+++ b/e2e/tests/test_chat_room.py
@@ -153,6 +153,39 @@ def test_document_title_flags_unseen_message_when_tab_unfocused(make_page, base_
     expect(bob).to_have_title(default_title)
 
 
+def test_timer_modal_sets_countdown_visible_to_both_peers(make_page, base_url):
+    alice = make_page()
+    room_url = create_room(alice, base_url, "Alice")
+    bob = make_page()
+    join_room(bob, room_url, "Bob")
+    wait_for_send_ready(alice)
+    wait_for_send_ready(bob)
+
+    expect(alice.locator("#timer-button")).to_have_text("Timer")
+    alice.click("#timer-button")
+    expect(alice.get_by_text("Self-destruct timer")).to_be_visible()
+    alice.click("button[data-minutes='10']")
+
+    expect(alice.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+    expect(bob.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+
+
+def test_timer_state_is_synced_to_a_peer_joining_afterwards(make_page, base_url):
+    # The timer doesn't depend on the E2EE handshake completing, so Alice
+    # can set it while still alone in the room, well before Bob joins.
+    alice = make_page()
+    room_url = create_room(alice, base_url, "Alice")
+    expect(alice.locator("#timer-button")).to_be_visible()
+
+    alice.click("#timer-button")
+    alice.click("button[data-minutes='10']")
+    expect(alice.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+
+    bob = make_page()
+    join_room(bob, room_url, "Bob")
+    expect(bob.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"), timeout=15000)
+
+
 def test_invite_modal_shows_room_url_and_copy_shows_toast(make_page, base_url):
     alice = make_page()
     room_url = create_room(alice, base_url, "Alice")

--- a/lib/chatsec_web/channel_state.ex
+++ b/lib/chatsec_web/channel_state.ex
@@ -10,6 +10,11 @@ defmodule ChatsecWeb.ChannelState do
   the table's heir keeps the table (and the room data in it) alive across
   such a crash-and-restart; a deliberate, normal stop (e.g. in tests) still
   tears the table down in `terminate/2`, so repeated test runs stay isolated.
+
+  Self-destruct timers (see set_expiry/3) live only in this process's own
+  GenServer state, not the ETS table - losing a scheduled timer on a crash
+  is a low-stakes edge case (the room just outlives its timer instead of
+  disappearing on schedule), unlike losing the room list itself.
   """
   use GenServer
 
@@ -51,6 +56,22 @@ defmodule ChatsecWeb.ChannelState do
     GenServer.call(pid, {:leave, room_id, identifier})
   end
 
+  # Schedules the room for deletion in `ms` milliseconds, replacing any
+  # timer already pending for it. Fires even if the room is empty/full/idle -
+  # this is a hard lifetime cap, not another empty-room sweep.
+  def set_expiry(pid \\ __MODULE__, room_id, ms) do
+    GenServer.call(pid, {:set_expiry, room_id, ms})
+  end
+
+  def clear_expiry(pid \\ __MODULE__, room_id) do
+    GenServer.call(pid, {:clear_expiry, room_id})
+  end
+
+  # Milliseconds remaining until the room's timer fires, or nil if none is set.
+  def get_expiry(pid \\ __MODULE__, room_id) do
+    GenServer.call(pid, {:get_expiry, room_id})
+  end
+
   @impl true
   def init(name) do
     # terminate/2 is only guaranteed to run on a supervisor-initiated
@@ -65,7 +86,7 @@ defmodule ChatsecWeb.ChannelState do
         tid -> tid
       end
 
-    {:ok, table}
+    {:ok, %{table: table, timers: %{}}}
   end
 
   defp heir_opts do
@@ -76,67 +97,67 @@ defmodule ChatsecWeb.ChannelState do
   end
 
   @impl true
-  def terminate(reason, table) when reason in [:normal, :shutdown] do
+  def terminate(reason, %{table: table}) when reason in [:normal, :shutdown] do
     :ets.delete(table)
     :ok
   end
 
-  def terminate({:shutdown, _}, table) do
+  def terminate({:shutdown, _}, %{table: table}) do
     :ets.delete(table)
     :ok
   end
 
-  def terminate(_reason, _table), do: :ok
+  def terminate(_reason, _state), do: :ok
 
   @impl true
-  def handle_call({:list_users, room_id}, _from, table) do
-    {:reply, lookup(table, room_id), table}
+  def handle_call({:list_users, room_id}, _from, %{table: table} = state) do
+    {:reply, lookup(table, room_id), state}
   end
 
   @impl true
-  def handle_call({:create, room_id}, _from, table) do
+  def handle_call({:create, room_id}, _from, %{table: table} = state) do
     :ets.insert(table, {room_id, []})
-    {:reply, :ok, table}
+    {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:delete, room_id}, _from, table) do
+  def handle_call({:delete, room_id}, _from, %{table: table} = state) do
     :ets.delete(table, room_id)
-    {:reply, :ok, table}
+    {:reply, :ok, cancel_timer(state, room_id)}
   end
 
   @impl true
-  def handle_call(:delete_empty, _from, table) do
+  def handle_call(:delete_empty, _from, %{table: table} = state) do
     :ets.match_delete(table, {:_, []})
-    {:reply, :ok, table}
+    {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call(:list_rooms, _from, table) do
+  def handle_call(:list_rooms, _from, %{table: table} = state) do
     rooms = :ets.select(table, [{{:"$1", :_}, [], [:"$1"]}])
-    {:reply, rooms, table}
+    {:reply, rooms, state}
   end
 
   @impl true
-  def handle_call({:join, room_id, identifier}, _from, table) do
+  def handle_call({:join, room_id, identifier}, _from, %{table: table} = state) do
     :ets.insert(table, {room_id, add_identifier(lookup(table, room_id), identifier)})
-    {:reply, :ok, table}
+    {:reply, :ok, state}
   end
 
   @impl true
-  def handle_call({:try_join, room_id, identifier}, _from, table) do
+  def handle_call({:try_join, room_id, identifier}, _from, %{table: table} = state) do
     users = lookup(table, room_id)
 
     if length(users) < 2 do
       :ets.insert(table, {room_id, add_identifier(users, identifier)})
-      {:reply, :ok, table}
+      {:reply, :ok, state}
     else
-      {:reply, {:error, :room_full}, table}
+      {:reply, {:error, :room_full}, state}
     end
   end
 
   @impl true
-  def handle_call({:leave, room_id, identifier}, _from, table) do
+  def handle_call({:leave, room_id, identifier}, _from, %{table: table} = state) do
     case :ets.lookup(table, room_id) do
       [{^room_id, users}] ->
         :ets.insert(table, {room_id, Enum.reject(users, &(&1 == identifier))})
@@ -145,7 +166,48 @@ defmodule ChatsecWeb.ChannelState do
         :ok
     end
 
-    {:reply, :ok, table}
+    {:reply, :ok, state}
+  end
+
+  @impl true
+  def handle_call({:set_expiry, room_id, ms}, _from, state) do
+    state = cancel_timer(state, room_id)
+    ref = Process.send_after(self(), {:expire, room_id}, ms)
+    {:reply, :ok, put_in(state.timers[room_id], ref)}
+  end
+
+  @impl true
+  def handle_call({:clear_expiry, room_id}, _from, state) do
+    {:reply, :ok, cancel_timer(state, room_id)}
+  end
+
+  @impl true
+  def handle_call({:get_expiry, room_id}, _from, %{timers: timers} = state) do
+    remaining =
+      with ref when ref != nil <- timers[room_id],
+           ms when is_integer(ms) <- Process.read_timer(ref) do
+        ms
+      else
+        _ -> nil
+      end
+
+    {:reply, remaining, state}
+  end
+
+  @impl true
+  def handle_info({:expire, room_id}, %{table: table} = state) do
+    :ets.delete(table, room_id)
+    ChatsecWeb.Endpoint.broadcast!("room:" <> room_id, "room_deleted", %{})
+    {:noreply, %{state | timers: Map.delete(state.timers, room_id)}}
+  end
+
+  defp cancel_timer(state, room_id) do
+    case state.timers[room_id] do
+      nil -> state
+      ref -> Process.cancel_timer(ref)
+    end
+
+    %{state | timers: Map.delete(state.timers, room_id)}
   end
 
   defp lookup(table, room_id) do

--- a/lib/chatsec_web/channels/room_channel.ex
+++ b/lib/chatsec_web/channels/room_channel.ex
@@ -13,6 +13,9 @@ defmodule ChatsecWeb.RoomChannel do
   # other's browser or forcing repeated expensive ECDH derivations.
   @rate_limit_window_ms 5_000
   @rate_limit_max_events 20
+  # 0 means "off". Fixed options rather than an arbitrary client-supplied
+  # duration - never trust the client for a value that schedules server work.
+  @allowed_timer_minutes [0, 10, 30, 60]
 
   def join("room:" <> room_id, %{"username" => username}, socket)
       when is_binary(username) do
@@ -79,6 +82,30 @@ defmodule ChatsecWeb.RoomChannel do
     end
   end
 
+  # Either peer can set/change/clear this - a 2-person room doesn't have a
+  # meaningful "owner" once both are in it. Broadcasts (not broadcast_from!)
+  # since this is UI state both sides should stay in sync on, not something
+  # the sender already renders locally like new_msg does.
+  def handle_in("set_timer", %{"minutes" => minutes}, socket)
+      when minutes in @allowed_timer_minutes do
+    case check_rate_limit(socket) do
+      {:ok, socket} ->
+        ms = minutes * 60_000
+
+        if minutes == 0 do
+          ChannelState.clear_expiry(socket.assigns.room_id)
+        else
+          ChannelState.set_expiry(socket.assigns.room_id, ms)
+        end
+
+        broadcast!(socket, "timer_set", %{"ms" => ms})
+        {:noreply, socket}
+
+      {:error, socket} ->
+        {:noreply, socket}
+    end
+  end
+
   def handle_in("adios", _, socket) do
     ChannelState.delete_room(socket.assigns.room_id)
     broadcast!(socket, "room_deleted", %{})
@@ -112,7 +139,18 @@ defmodule ChatsecWeb.RoomChannel do
   def handle_info({:after_join, username}, socket) do
     track_user_presence(socket, username)
     broadcast!(socket, "after_join", %{"username" => username})
+    push_current_timer(socket)
     {:noreply, socket}
+  end
+
+  # If a timer was already set before this peer joined (or they're
+  # rejoining after a refresh), tell them where the countdown currently
+  # stands rather than leaving their UI with no indication it's running.
+  defp push_current_timer(socket) do
+    case ChannelState.get_expiry(socket.assigns.room_id) do
+      nil -> :ok
+      remaining_ms -> push(socket, "timer_set", %{"ms" => remaining_ms})
+    end
   end
 
   def terminate(_, socket) do

--- a/lib/chatsec_web/controllers/page_html/chat.html.heex
+++ b/lib/chatsec_web/controllers/page_html/chat.html.heex
@@ -31,6 +31,13 @@
     </div>
     <div class="flex gap-2">
       <button
+        id="timer-button"
+        class="rounded-lg bg-gray-700 px-3 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
+        title="Automatically delete this room after a set time"
+      >
+        Timer
+      </button>
+      <button
         id="verify-button"
         class="hidden rounded-lg bg-gray-700 px-3 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
         title="Verify this connection hasn't been intercepted"

--- a/test/chatsec_web/channel_state_test.exs
+++ b/test/chatsec_web/channel_state_test.exs
@@ -50,6 +50,56 @@ defmodule ChatsecWeb.ChannelStateTest do
     assert [occupied_room] == ChannelState.get_rooms(pid)
   end
 
+  test "a room's timer deletes it after the given duration", %{pid: pid} do
+    room_id = UUID.uuid4()
+    assert :ok == ChannelState.create_room(pid, room_id)
+    assert :ok == ChannelState.set_expiry(pid, room_id, 10)
+
+    Process.sleep(30)
+    assert [] == ChannelState.get_rooms(pid)
+  end
+
+  test "clear_expiry cancels a pending timer", %{pid: pid} do
+    room_id = UUID.uuid4()
+    assert :ok == ChannelState.create_room(pid, room_id)
+    assert :ok == ChannelState.set_expiry(pid, room_id, 10)
+    assert :ok == ChannelState.clear_expiry(pid, room_id)
+
+    Process.sleep(30)
+    assert [room_id] == ChannelState.get_rooms(pid)
+  end
+
+  test "setting a new expiry replaces the previous one instead of stacking", %{pid: pid} do
+    room_id = UUID.uuid4()
+    assert :ok == ChannelState.create_room(pid, room_id)
+    assert :ok == ChannelState.set_expiry(pid, room_id, 10)
+    assert :ok == ChannelState.set_expiry(pid, room_id, 60_000)
+
+    # If the first (10ms) timer had fired anyway, the room would be gone.
+    Process.sleep(30)
+    assert [room_id] == ChannelState.get_rooms(pid)
+  end
+
+  test "get_expiry reports nil with no timer, remaining ms with one set", %{pid: pid} do
+    room_id = UUID.uuid4()
+    assert :ok == ChannelState.create_room(pid, room_id)
+    assert nil == ChannelState.get_expiry(pid, room_id)
+
+    assert :ok == ChannelState.set_expiry(pid, room_id, 60_000)
+    remaining = ChannelState.get_expiry(pid, room_id)
+    assert is_integer(remaining)
+    assert remaining > 0 and remaining <= 60_000
+  end
+
+  test "an expiry firing broadcasts room_deleted on the room's topic", %{pid: pid} do
+    room_id = UUID.uuid4()
+    Phoenix.PubSub.subscribe(Chatsec.PubSub, "room:" <> room_id)
+    assert :ok == ChannelState.create_room(pid, room_id)
+    assert :ok == ChannelState.set_expiry(pid, room_id, 10)
+
+    assert_receive %Phoenix.Socket.Broadcast{event: "room_deleted"}, 200
+  end
+
   test "room data survives an abnormal crash-and-restart, but not a normal stop" do
     {:ok, pid} = ChannelState.start_link(name: :crash_test)
     room_id = UUID.uuid4()

--- a/test/chatsec_web/channels/room_channel_test.exs
+++ b/test/chatsec_web/channels/room_channel_test.exs
@@ -72,6 +72,33 @@ defmodule ChatsecWeb.RoomChannelTest do
     refute_push "typing", %{}, 100
   end
 
+  test "set_timer is broadcast to both peers, including the sender", %{room_id: room_id} do
+    {:ok, _, alice} = join_room(socket_fixture(), room_id, "Alice")
+
+    push(alice, "set_timer", %{"minutes" => 10})
+
+    assert_broadcast "timer_set", %{"ms" => 600_000}
+  end
+
+  test "a joiner is told about a timer already set before they arrived", %{room_id: room_id} do
+    {:ok, _, alice} = join_room(socket_fixture(), room_id, "Alice")
+    push(alice, "set_timer", %{"minutes" => 10})
+    assert_broadcast "timer_set", %{"ms" => 600_000}
+
+    {:ok, _, _bob} = join_room(socket_fixture(), room_id, "Bob")
+
+    assert_push "timer_set", %{"ms" => ms}, 500
+    assert ms > 0 and ms <= 600_000
+  end
+
+  test "an invalid timer duration is ignored", %{room_id: room_id} do
+    {:ok, _, socket} = join_room(socket_fixture(), room_id, "Alice")
+
+    push(socket, "set_timer", %{"minutes" => 5})
+
+    refute_broadcast "timer_set", %{}
+  end
+
   test "an oversized new_msg is dropped instead of broadcast", %{room_id: room_id} do
     {:ok, _, socket} = join_room(socket_fixture(), room_id, "Alice")
 


### PR DESCRIPTION
## Summary
- Either peer can set a room to auto-delete after a fixed duration (10/30/60 min, or off) via a new "Timer" button in the chat header, regardless of activity - a hard lifetime cap, not another empty-room sweep.
- `ChannelState` schedules the deletion with `Process.send_after` and tracks the timer ref in its own GenServer state (not the ETS table - losing a scheduled timer on a crash-restart is low-stakes, unlike losing the room list). When it fires, the room is deleted and `room_deleted` is broadcast directly via the Endpoint, reusing the same client-side redirect handling as the manual "Delete" flow.
- `RoomChannel` validates the duration against a fixed allowlist (`[0, 10, 30, 60]`) rather than trusting an arbitrary client-supplied value, and syncs the current countdown to a peer who joins (or rejoins) after the timer was already set.

## Test plan
- [x] `mix test` - 29/29 passing (new: expiry actually deletes the room, clear/replace a pending timer, get_expiry, room_deleted broadcast, set_timer validation/broadcast/late-joiner sync)
- [x] Full e2e suite - 36/36 passing (new: timer modal sets a visible countdown for both peers, countdown syncs to a peer joining afterwards)
- [x] Manually verified live in the browser: opened the modal, set a 10-minute timer, confirmed the header button turns into a live countdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)