### PR TITLE
Fix mobile header overflow root cause and add regression coverage

### DIFF
--- a/assets/js/fingerprint.js
+++ b/assets/js/fingerprint.js
@@ -10,7 +10,9 @@ const FINGERPRINT_ICON = `
 
 function setFingerprint(fingerprint) {
 	currentFingerprint = fingerprint;
-	document.getElementById("verify-button")?.classList.remove("hidden");
+	const button = document.getElementById("verify-button");
+	button?.classList.remove("hidden");
+	button?.classList.add("flex");
 }
 
 function showFingerprintModal() {

--- a/assets/js/timer.js
+++ b/assets/js/timer.js
@@ -24,29 +24,35 @@ function formatRemaining(ms) {
 	const seconds = totalSeconds % 60;
 	return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
-function updateButtonLabel() {
-	const button = document.getElementById("timer-button");
-	if (!button) return;
+function updateDisplays() {
+	const label = document.getElementById("timer-label");
+	const mobileCountdown = document.getElementById("timer-mobile-countdown");
 	if (!expiresAt) {
-		button.textContent = "Timer";
+		if (label) label.textContent = "Timer";
+		mobileCountdown?.classList.add("hidden");
 		return;
 	}
 	const remaining = expiresAt - Date.now();
 	if (remaining <= 0) {
 		clearInterval(countdownInterval);
 	}
-	button.textContent = formatRemaining(remaining);
+	const text = formatRemaining(remaining);
+	if (label) label.textContent = text;
+	if (mobileCountdown) {
+		mobileCountdown.textContent = `Auto-deletes in ${text}`;
+		mobileCountdown.classList.remove("hidden");
+	}
 }
 function startCountdown(ms) {
 	clearInterval(countdownInterval);
 	if (!ms) {
 		expiresAt = null;
-		updateButtonLabel();
+		updateDisplays();
 		return;
 	}
 	expiresAt = Date.now() + ms;
-	updateButtonLabel();
-	countdownInterval = setInterval(updateButtonLabel, 1000);
+	updateDisplays();
+	countdownInterval = setInterval(updateDisplays, 1000);
 }
 function handleTimerSet(payload) {
 	startCountdown(payload.ms);

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,8 +1,9 @@
 # ChatSec end-to-end tests
 
 Browser-driven tests (Playwright + pytest) covering the full app: home page,
-username flow, chat room messaging/presence/invite/delete, room capacity,
-error pages, and the security response headers.
+username flow, chat room messaging/presence/invite/delete/verify/typing
+indicator/self-destruct timer, room capacity, error pages, and the security
+response headers.
 
 ## Setup
 
@@ -50,3 +51,14 @@ poetry run pytest --headed --slowmo 250  # watch it run
   configured (see `config/prod.exs`), which is intentionally off in dev to
   avoid forcing HTTPS redirects during local development. It is not exercised
   by this suite; see the root `CLAUDE.md` for how it's verified instead.
+- Tests for the unfocused-tab title notification force
+  `document.hasFocus = () => false` via `page.evaluate` rather than relying
+  on real OS window focus — headless multi-context focus isn't something a
+  browser's own window manager drives predictably across independent
+  Playwright contexts, so the test overrides the exact check the app
+  actually makes instead.
+- Nothing here drives a mobile-width viewport. The chat header's
+  responsive icon-only layout below the `sm` breakpoint
+  (`chat.html.heex`/`timer.js` — see `CLAUDE.md`'s frontend-conventions
+  section) was verified manually in a resized browser, not by an
+  automated test in this suite — worth adding if that layout changes again.

--- a/e2e/tests/test_chat_room.py
+++ b/e2e/tests/test_chat_room.py
@@ -161,13 +161,13 @@ def test_timer_modal_sets_countdown_visible_to_both_peers(make_page, base_url):
     wait_for_send_ready(alice)
     wait_for_send_ready(bob)
 
-    expect(alice.locator("#timer-button")).to_have_text("Timer")
+    expect(alice.locator("#timer-label")).to_have_text("Timer")
     alice.click("#timer-button")
     expect(alice.get_by_text("Self-destruct timer")).to_be_visible()
     alice.click("button[data-minutes='10']")
 
-    expect(alice.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
-    expect(bob.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+    expect(alice.locator("#timer-label")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+    expect(bob.locator("#timer-label")).to_have_text(re.compile(r"^(9|10):\d\d$"))
 
 
 def test_timer_state_is_synced_to_a_peer_joining_afterwards(make_page, base_url):
@@ -179,11 +179,47 @@ def test_timer_state_is_synced_to_a_peer_joining_afterwards(make_page, base_url)
 
     alice.click("#timer-button")
     alice.click("button[data-minutes='10']")
-    expect(alice.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+    expect(alice.locator("#timer-label")).to_have_text(re.compile(r"^(9|10):\d\d$"))
 
     bob = make_page()
     join_room(bob, room_url, "Bob")
-    expect(bob.locator("#timer-button")).to_have_text(re.compile(r"^(9|10):\d\d$"), timeout=15000)
+    expect(bob.locator("#timer-label")).to_have_text(re.compile(r"^(9|10):\d\d$"), timeout=15000)
+
+
+def test_header_buttons_stay_within_the_viewport_on_mobile(make_page, base_url):
+    """Regression test: on a phone-width screen, the header's Timer/Verify/
+    Invite/Delete buttons must never be pushed outside the visible viewport -
+    not by default, not with long usernames (which take more of the header's
+    width and used to squeeze the button row along with it), and not while a
+    self-destruct timer is actively counting down (all three combined to
+    push Delete out of frame before the header/timer.js layout fix)."""
+    alice = make_page()
+    alice.set_viewport_size({"width": 375, "height": 812})
+    room_url = create_room(alice, base_url, "asmodeus")
+    bob = make_page()
+    join_room(bob, room_url, "belphegor")
+    wait_for_send_ready(alice)
+    wait_for_send_ready(bob)
+
+    viewport_width = 375
+    button_ids = ["#timer-button", "#verify-button", "#invite-button", "#showDeleteChatModal"]
+
+    def assert_buttons_in_bounds():
+        for button_id in button_ids:
+            box = alice.locator(button_id).bounding_box()
+            assert box is not None, f"{button_id} has no bounding box"
+            assert box["x"] >= 0, f"{button_id} starts off the left edge"
+            assert box["x"] + box["width"] <= viewport_width, (
+                f"{button_id} overflows the {viewport_width}px viewport "
+                f"(right edge at {box['x'] + box['width']})"
+            )
+
+    assert_buttons_in_bounds()
+
+    alice.click("#timer-button")
+    alice.click("button[data-minutes='10']")
+    expect(alice.locator("#timer-label")).to_have_text(re.compile(r"^(9|10):\d\d$"))
+    assert_buttons_in_bounds()
 
 
 def test_invite_modal_shows_room_url_and_copy_shows_toast(make_page, base_url):

--- a/lib/chatsec_web/controllers/page_html/chat.html.heex
+++ b/lib/chatsec_web/controllers/page_html/chat.html.heex
@@ -5,62 +5,92 @@
   </div>
 
   <%!-- Header --%>
-  <header class="relative flex shrink-0 items-center justify-between gap-2 border-b border-gray-700 bg-gray-800 px-4 py-3">
-    <div class="flex min-w-0 items-center gap-2.5">
-      <svg viewBox="0 0 200 200" class="h-7 w-7 shrink-0" aria-hidden="true">
-        <defs>
-          <linearGradient id="logoGradChat" x1="0%" y1="0%" x2="100%" y2="100%">
-            <stop offset="0%" stop-color="#a78bfa" />
-            <stop offset="100%" stop-color="#4c1d95" />
-          </linearGradient>
-        </defs>
-        <path
-          d="M58 134C56 152 48 168 34 180C57 173 74 158 82 136Z"
-          fill="url(#logoGradChat)"
-        />
-        <rect x="20" y="24" width="160" height="116" rx="36" fill="url(#logoGradChat)" />
-        <circle cx="100" cy="72" r="17" fill="#f5f3ff" />
-        <path d="M91 84L109 84L116 114Q100 124 84 114Z" fill="#f5f3ff" />
-      </svg>
-      <div class="min-w-0">
-        <h1 class="text-sm font-bold leading-tight text-white">ChatSec</h1>
-        <div id="users">
-          <ul id="usernames" class="flex flex-wrap gap-x-2 text-xs text-gray-400"></ul>
+  <header class="relative flex shrink-0 flex-col gap-1 border-b border-gray-700 bg-gray-800 px-4 py-3">
+    <div class="flex items-center justify-between gap-2">
+      <div class="flex min-w-0 items-center gap-2.5">
+        <svg viewBox="0 0 200 200" class="h-7 w-7 shrink-0" aria-hidden="true">
+          <defs>
+            <linearGradient id="logoGradChat" x1="0%" y1="0%" x2="100%" y2="100%">
+              <stop offset="0%" stop-color="#a78bfa" />
+              <stop offset="100%" stop-color="#4c1d95" />
+            </linearGradient>
+          </defs>
+          <path
+            d="M58 134C56 152 48 168 34 180C57 173 74 158 82 136Z"
+            fill="url(#logoGradChat)"
+          />
+          <rect x="20" y="24" width="160" height="116" rx="36" fill="url(#logoGradChat)" />
+          <circle cx="100" cy="72" r="17" fill="#f5f3ff" />
+          <path d="M91 84L109 84L116 114Q100 124 84 114Z" fill="#f5f3ff" />
+        </svg>
+        <div class="min-w-0">
+          <h1 class="text-sm font-bold leading-tight text-white">ChatSec</h1>
+          <div id="users">
+            <ul id="usernames" class="flex flex-wrap gap-x-2 text-xs text-gray-400"></ul>
+          </div>
         </div>
       </div>
+      <%!-- Icon-only on mobile (label hidden below sm) - four full-label buttons
+           plus the logo/username block never fit on a phone-width header, and
+           a clipped-off Delete button is worse than an icon-only one. The
+           Timer button stays icon-only on mobile too, even while counting
+           down - the live countdown shows on its own line below instead
+           (#timer-mobile-countdown), so the button row width never changes
+           based on timer state. Each button keeps its accessible name via
+           title even when the visible label is hidden. shrink-0 here (not
+           min-w-0) is deliberate: the buttons are fixed, non-negotiable
+           content, so a long username (the left side has min-w-0 and wraps
+           via flex-wrap) gives up space first rather than the two sides
+           splitting the squeeze and clipping a button anyway.
+           overflow-x-auto is a last-resort safety net, not the primary fit. --%>
+      <div class="flex shrink-0 items-center gap-1.5 overflow-x-auto">
+        <button
+          id="timer-button"
+          class="flex shrink-0 items-center gap-1.5 rounded-lg bg-gray-700 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
+          title="Automatically delete this room after a set time"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M12 6v6h4.5m4.5 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"/>
+          </svg>
+          <span id="timer-label" class="hidden sm:inline">Timer</span>
+        </button>
+        <button
+          id="verify-button"
+          class="hidden shrink-0 items-center gap-1.5 rounded-lg bg-gray-700 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
+          title="Verify this connection hasn't been intercepted"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M7.864 4.243A7.5 7.5 0 0 1 19.5 10.5c0 2.92-.556 5.709-1.568 8.268M5.742 6.364A7.465 7.465 0 0 0 4.5 10.5a7.464 7.464 0 0 1-1.15 3.993m1.989 3.559A11.209 11.209 0 0 0 8.25 10.5a3.75 3.75 0 1 1 7.5 0c0 .527-.021 1.049-.064 1.565M12 10.5a14.94 14.94 0 0 1-3.6 9.75m6.633-4.596a18.666 18.666 0 0 1-2.485 5.33"/>
+          </svg>
+          <span class="hidden sm:inline">Verify</span>
+        </button>
+        <button
+          id="invite-button"
+          class="flex shrink-0 items-center gap-1.5 rounded-lg bg-violet-500 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 active:bg-violet-800"
+          title="Invite a second person to this room"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M13.19 8.688a4.5 4.5 0 0 1 1.242 7.244l-4.5 4.5a4.5 4.5 0 0 1-6.364-6.364l1.757-1.757m13.35-.622 1.757-1.757a4.5 4.5 0 0 0-6.364-6.364l-4.5 4.5a4.5 4.5 0 0 0 1.242 7.244"/>
+          </svg>
+          <span class="hidden sm:inline">Invite</span>
+        </button>
+        <button
+          id="showDeleteChatModal"
+          class="flex shrink-0 items-center gap-1.5 rounded-lg bg-pink-600 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-500 active:bg-pink-800"
+          title="Permanently delete this room for both of you"
+        >
+          <svg class="h-5 w-5 shrink-0" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="m14.74 9-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 0 1-2.244 2.077H8.084a2.25 2.25 0 0 1-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 0 0-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 0 1 3.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 0 0-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 0 0-7.5 0"/>
+          </svg>
+          <span class="hidden sm:inline">Delete</span>
+        </button>
+      </div>
     </div>
-    <%!-- overflow-x-auto is a safety net, not the primary fit: on a phone-width
-         screen these four buttons plus the logo/username block don't all fit
-         at once, and a clipped-off Delete button would be worse than a
-         scrollable one. --%>
-    <div class="flex min-w-0 gap-1.5 overflow-x-auto">
-      <button
-        id="timer-button"
-        class="shrink-0 rounded-lg bg-gray-700 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
-        title="Automatically delete this room after a set time"
-      >
-        Timer
-      </button>
-      <button
-        id="verify-button"
-        class="hidden shrink-0 rounded-lg bg-gray-700 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 active:bg-gray-800"
-        title="Verify this connection hasn't been intercepted"
-      >
-        Verify
-      </button>
-      <button
-        id="invite-button"
-        class="shrink-0 rounded-lg bg-violet-500 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-violet-700 focus:outline-none focus:ring-2 focus:ring-violet-500 active:bg-violet-800"
-      >
-        Invite
-      </button>
-      <button
-        id="showDeleteChatModal"
-        class="shrink-0 rounded-lg bg-pink-600 px-2.5 py-1.5 text-sm font-bold text-white transition duration-150 hover:bg-pink-700 focus:outline-none focus:ring-2 focus:ring-pink-500 active:bg-pink-800"
-      >
-        Delete
-      </button>
-    </div>
+    <%!-- Mobile-only (sm:hidden) countdown line - the Timer button itself
+         never widens on mobile, so this is the only place the countdown is
+         visible below the sm breakpoint. Toggled by timer.js, same "hidden"
+         pattern as #typing-indicator in the footer. --%>
+    <p id="timer-mobile-countdown" class="hidden sm:hidden px-1 text-xs text-gray-400"></p>
   </header>
 
   <%!-- Messages --%>


### PR DESCRIPTION
## Summary
- Root cause of the mobile "Delete pushed out of frame" bug wasn't the timer specifically — the button row and username list were both allowed to shrink and negotiate space, so a long username alone was enough to squeeze the header row. The button row is now `shrink-0` instead of `min-w-0`, so it always gets its full guaranteed width; the username/logo side yields space first.
- The self-destruct countdown now shows on its own line below the buttons on mobile (`#timer-mobile-countdown`) instead of widening the Timer button inline, so the button row's width never changes based on timer state.
- Added a Playwright regression test that resizes to a phone viewport, joins with long usernames, and asserts all four header buttons stay fully in-bounds by default and with an active timer.

## Test plan
- [x] `mix test` — 29/29 passing
- [x] Full e2e suite — 37/37 passing (new: `test_header_buttons_stay_within_the_viewport_on_mobile`)
- [x] Confirmed the new test actually fails without the fix (reverted `shrink-0` → `min-w-0`, watched it fail with the exact overflow assertion, restored the fix)
- [x] Manually verified in the browser at 375px with long usernames, both timer on and off, and at desktop width

🤖 Generated with [Claude Code](https://claude.com/claude-code)