### PR TITLE
Add a fallback error template so unhandled statuses don't crash

### DIFF
--- a/lib/chatsec_web/controllers/error_html.ex
+++ b/lib/chatsec_web/controllers/error_html.ex
@@ -15,7 +15,15 @@ defmodule ChatsecWeb.ErrorHTML do
   #
   embed_templates "error_html/*"
 
-  # The default is to render a plain text page based on
-  # the template name. For example, "404.html" becomes
-  # "Not Found".
+  # embed_templates/1 above only covers the statuses that have a matching
+  # .heex file (404, 500) - any other status Phoenix asks for (400 from a
+  # malformed request body, 403, 422, etc.) would otherwise crash with
+  # "no \"<status>\" html template defined" instead of just responding. This
+  # mirrors Phoenix's own un-customized default: a plain text page based on
+  # the template name, e.g. "400.html" becomes "Bad Request". These statuses
+  # are overwhelmingly bot/scanner traffic hitting nonexistent routes or
+  # sending garbage bodies, not real users, so a plain fallback is enough.
+  def render(template, _assigns) do
+    Phoenix.Controller.status_message_from_template(template)
+  end
 end

--- a/test/chatsec_web/controllers/error_html_test.exs
+++ b/test/chatsec_web/controllers/error_html_test.exs
@@ -1,3 +1,16 @@
 defmodule ChatsecWeb.ErrorHTMLTest do
   use ChatsecWeb.ConnCase, async: true
+
+  test "a status with no dedicated template (e.g. 400) falls back instead of crashing" do
+    assert Phoenix.Template.render_to_string(ChatsecWeb.ErrorHTML, "400", "html", []) ==
+             "Bad Request"
+  end
+
+  test "a malformed request body doesn't crash the endpoint", %{conn: conn} do
+    conn = put_req_header(conn, "content-type", "application/json")
+
+    assert_error_sent 400, fn ->
+      post(conn, "/", "{not valid json")
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- `ChatsecWeb.ErrorHTML` only had templates for 404 and 500 (`embed_templates/1` picks up whatever `.heex` files exist), so any other status Phoenix needed to render - 400 from a malformed request body, 403, 422, etc. - crashed with `no "<status>" html template defined` instead of just responding.
- Seen in production: a bot sent a malformed POST to `/` (no route even accepts POST there), which tripped `Plug.Parsers` into a genuine 400, which then crashed a *second* time trying to render a 400 page that didn't exist - turning harmless scanner noise into a real error in the logs.
- Adds a catch-all `render/2` that falls back to a plain status message (e.g. "Bad Request"), matching Phoenix's own un-customized default. This traffic is overwhelmingly bots, not real users, so a plain fallback is the right level of effort here.

## Test plan
- [x] Two new regression tests in `error_html_test.exs` reproduce the exact production stack trace
- [x] Confirmed both fail with the identical `ArgumentError` before the fix, pass after
- [x] `mix test` - 31/31 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)