### PR TITLE
Add a Traefik healthcheck for the chatsec container

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -12,6 +12,13 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.chatsec.loadbalancer.server.port=4000"
+      # Traefik polls this itself (not a Docker-level HEALTHCHECK) and stops
+      # routing new requests to the container the moment a poll fails or
+      # times out, rather than proxying into a container that's up but not
+      # actually responding.
+      - "traefik.http.services.chatsec.loadbalancer.healthcheck.path=/health"
+      - "traefik.http.services.chatsec.loadbalancer.healthcheck.interval=10s"
+      - "traefik.http.services.chatsec.loadbalancer.healthcheck.timeout=5s"
       - "traefik.http.routers.chatsec.rule=Host(`chatsec.app`)"
       - "traefik.http.routers.chatsec.entrypoints=websecure"
       - "traefik.http.routers.chatsec.tls=true"

--- a/lib/chatsec_web/controllers/page_controller.ex
+++ b/lib/chatsec_web/controllers/page_controller.ex
@@ -2,6 +2,12 @@ defmodule ChatsecWeb.PageController do
   use ChatsecWeb, :controller
   alias ChatsecWeb.ChannelState
 
+  # Deliberately outside the :browser pipeline (see router.ex) - no session,
+  # CSRF, or layout work, just confirms the app is up and responding.
+  def health(conn, _params) do
+    send_resp(conn, 200, "OK")
+  end
+
   def home(conn, _params) do
     render(conn, :home, layout: false)
   end

--- a/lib/chatsec_web/router.ex
+++ b/lib/chatsec_web/router.ex
@@ -13,6 +13,13 @@ defmodule ChatsecWeb.Router do
     plug :accepts, ["json"]
   end
 
+  # No :browser pipeline here on purpose - Traefik polls this constantly
+  # (see compose.yaml), and it has no business paying for session/CSRF/
+  # layout setup on every poll.
+  scope "/", ChatsecWeb do
+    get "/health", PageController, :health
+  end
+
   scope "/", ChatsecWeb do
     pipe_through :browser
     get "/", PageController, :home

--- a/test/chatsec_web/controllers/page_controller_test.exs
+++ b/test/chatsec_web/controllers/page_controller_test.exs
@@ -5,4 +5,9 @@ defmodule ChatsecWeb.PageControllerTest do
     conn = get(conn, ~p"/")
     assert html_response(conn, 200) =~ "ChatSec"
   end
+
+  test "GET /health returns 200 for Traefik's healthcheck poll", %{conn: conn} do
+    conn = get(conn, ~p"/health")
+    assert response(conn, 200) == "OK"
+  end
 end


### PR DESCRIPTION
## Summary
- `GET /health` lives outside the `:browser` pipeline (no session/CSRF/layout work) and just returns `200 "OK"` - there's no database or other dependency to check, so confirming the app is up and responding is the whole check.
- Wired up via `traefik.http.services.chatsec.loadbalancer.healthcheck.*` labels in `compose.yaml`, not a Dockerfile `HEALTHCHECK`: Traefik polls the path itself every 10s (5s timeout) and pulls the container out of rotation the moment a poll fails or times out, rather than proxying new requests into a container that's up but not actually answering.

## Test plan
- [x] `mix test` - 32/32 passing (new: `GET /health` returns 200)
- [x] `docker compose config` - confirms the new labels parse correctly and are wired to the right service

🤖 Generated with [Claude Code](https://claude.com/claude-code)